### PR TITLE
wait for replay file to exist before renaming

### DIFF
--- a/src/LiveSplit.OBSEvents/OBS/Client.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Client.cs
@@ -1,11 +1,12 @@
 ﻿using LiveSplit.Model;
 using LiveSplit.OBSEvents.OBS.Protocol;
-using LiveSplit.OBSEvents.OBS.Protocol.Requests;
-using LiveSplit.OBSEvents.OBS.Protocol.Responses;
+using LiveSplit.OBSEvents.OBS.Protocol.Requests.Outputs;
+using LiveSplit.OBSEvents.OBS.Protocol.Responses.Outputs;
 using LiveSplit.OBSEvents.UI;
 using LiveSplit.OBSEvents.Utility;
 using LiveSplit.Web;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.WebSockets;
 using System.Security.Cryptography;
@@ -104,13 +105,21 @@ namespace LiveSplit.OBSEvents.OBS
 
         private async Task RunStartupTasks()
         {
+            IList<Message> requests = [];
             if (_settings.SaveBestSegmentReplay)
             {
-                // start the replay buffer if it isn't already started.
-                StartReplayBufferResponse startBuffer = await SendRequest(new StartReplayBuffer());
+                requests.Add(new StartReplayBuffer());
+            }
+
+            RequestBatchResponse taskResults = await SendRequestBatch(new RequestBatch(requests));
+            int i = 0;
+            if (_settings.SaveBestSegmentReplay)
+            {
+                StartReplayBufferResponse startBuffer = StartReplayBufferResponse.Transform(taskResults.Results[i++]);
                 if (!startBuffer.RequestStatus.Result && startBuffer.RequestStatus.Code != REQUEST_STATUS_OUTPUT_RUNNING)
                 {
                     Logger.Error($"Failed to start the replay buffer: {startBuffer.RequestStatus.Comment}");
+                    return;
                 }
             }
         }
@@ -132,14 +141,23 @@ namespace LiveSplit.OBSEvents.OBS
                     if (response.Results.Count > 1)
                     {
                         GetLastReplayBufferReplayResponse lastReplay = GetLastReplayBufferReplayResponse.Transform(response.Results[1]);
+                        
+                        while (!File.Exists(lastReplay.SavedReplayPath))
+                        {
+                            // The first saved replay takes extra time to show up for some reason.
+                            // Timestamps might not line up either. Need to keep asking until we get a match
+                            await Task.Delay(TimeSpan.FromSeconds(1));
+                            lastReplay = await SendRequest(new GetLastReplayBufferReplay());
+                        }
+                        
                         string newReplayName = ReplayFilenameFormatter.Format(_settings.ReplayNameFormat, state, splitIndex, segmentTime);
                         try
                         {
                             FileOperations.Rename(lastReplay.SavedReplayPath, newReplayName);
                         }
-                        catch (Exception e)
+                        catch (Exception ex)
                         {
-                            Logger.Warning($"Failed to rename replay file: {e.Message}");
+                            Logger.Warning($"Failed to rename replay file: {ex.Message}");
                         }
                     } 
                     else

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/RequestBatch.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/RequestBatch.cs
@@ -6,7 +6,7 @@ using LiveSplit.Web;
 
 namespace LiveSplit.OBSEvents.OBS.Protocol
 {
-    internal class RequestBatch(Message[] requests) : Message
+    internal class RequestBatch(IEnumerable<Message> requests) : Message
     {
         private const int OPCODE = 8;
 
@@ -14,7 +14,7 @@ namespace LiveSplit.OBSEvents.OBS.Protocol
 
         private string RequestId { get; } = Guid.NewGuid().ToString();
 
-        private Message[] Requests { get; } = requests;
+        private IEnumerable<Message> Requests { get; } = requests;
 
         internal override IDictionary<string, object> FieldValues()
         {

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/RequestResponse.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/RequestResponse.cs
@@ -8,7 +8,7 @@
 
         public RequestStatus RequestStatus { get; } = requestStatus;
 
-        protected static dynamic ExtractResponseData(dynamic json)
+        protected static dynamic ExtractAndValidateData(dynamic json)
         {
             return Message.ValidateAndExtractData(json, OPCODE, nameof(RequestResponse));
         }

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/Requests/Outputs/GetLastReplayBufferReplay.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/Requests/Outputs/GetLastReplayBufferReplay.cs
@@ -1,7 +1,7 @@
-﻿using LiveSplit.OBSEvents.OBS.Protocol.Responses;
+﻿using LiveSplit.OBSEvents.OBS.Protocol.Responses.Outputs;
 using System;
 
-namespace LiveSplit.OBSEvents.OBS.Protocol.Requests
+namespace LiveSplit.OBSEvents.OBS.Protocol.Requests.Outputs
 {
     internal class GetLastReplayBufferReplay : Request<GetLastReplayBufferReplayResponse>
     {

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/Requests/Outputs/SaveReplayBuffer.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/Requests/Outputs/SaveReplayBuffer.cs
@@ -1,8 +1,7 @@
 ﻿using System;
+using LiveSplit.OBSEvents.OBS.Protocol.Responses.Outputs;
 
-using LiveSplit.OBSEvents.OBS.Protocol.Responses;
-
-namespace LiveSplit.OBSEvents.OBS.Protocol.Requests
+namespace LiveSplit.OBSEvents.OBS.Protocol.Requests.Outputs
 {
     internal class SaveReplayBuffer : Request<SaveReplayBufferResponse>
     {

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/Requests/Outputs/StartReplayBuffer.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/Requests/Outputs/StartReplayBuffer.cs
@@ -1,7 +1,7 @@
-﻿using LiveSplit.OBSEvents.OBS.Protocol.Responses;
+﻿using LiveSplit.OBSEvents.OBS.Protocol.Responses.Outputs;
 using System;
 
-namespace LiveSplit.OBSEvents.OBS.Protocol.Requests
+namespace LiveSplit.OBSEvents.OBS.Protocol.Requests.Outputs
 {
     internal class StartReplayBuffer : Request<StartReplayBufferResponse>
     {

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/Responses/Outputs/GetLastReplayBufferReplayResponse.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/Responses/Outputs/GetLastReplayBufferReplayResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace LiveSplit.OBSEvents.OBS.Protocol.Responses
+﻿namespace LiveSplit.OBSEvents.OBS.Protocol.Responses.Outputs
 {
     internal class GetLastReplayBufferReplayResponse(string requestId, RequestStatus requestStatus, string savedReplayPath) : RequestResponse(requestId, requestStatus)
     {
@@ -6,7 +6,7 @@
 
         public static GetLastReplayBufferReplayResponse Parse(dynamic json)
         {
-            dynamic data = ExtractResponseData(json);
+            dynamic data = ExtractAndValidateData(json);
             return Transform(data);
         }
 

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/Responses/Outputs/SaveReplayBufferResponse.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/Responses/Outputs/SaveReplayBufferResponse.cs
@@ -1,10 +1,10 @@
-﻿namespace LiveSplit.OBSEvents.OBS.Protocol.Responses
+﻿namespace LiveSplit.OBSEvents.OBS.Protocol.Responses.Outputs
 {
     internal class SaveReplayBufferResponse(string requestId, RequestStatus requestStatus) : RequestResponse(requestId, requestStatus)
     {
         public static SaveReplayBufferResponse Parse(dynamic json)
         {
-            dynamic data = ExtractResponseData(json);
+            dynamic data = ExtractAndValidateData(json);
             return Transform(data);
         }
 

--- a/src/LiveSplit.OBSEvents/OBS/Protocol/Responses/Outputs/StartReplayBufferResponse.cs
+++ b/src/LiveSplit.OBSEvents/OBS/Protocol/Responses/Outputs/StartReplayBufferResponse.cs
@@ -1,10 +1,10 @@
-﻿namespace LiveSplit.OBSEvents.OBS.Protocol.Responses
+﻿namespace LiveSplit.OBSEvents.OBS.Protocol.Responses.Outputs
 {
     internal class StartReplayBufferResponse(string requestId, RequestStatus requestStatus) : RequestResponse(requestId, requestStatus)
     {
         public static StartReplayBufferResponse Parse(dynamic json)
         {
-            dynamic data = ExtractResponseData(json);
+            dynamic data = ExtractAndValidateData(json);
             return Transform(data);
         }
 


### PR DESCRIPTION
Fixes #13. I tried using a `FileSystemWatcher`, but it wasn't firing the `Created` event when I expected it to. Might have been hard to work with that anyways, since the first filename it gives us isn't correct sometimes if it includes a timestamp.