### PR TITLE
add configurable threshold for best segment replays

### DIFF
--- a/src/LiveSplit.OBSEvents/OBSEventsComponent.cs
+++ b/src/LiveSplit.OBSEvents/OBSEventsComponent.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using System.Xml;
-
 using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
 using LiveSplit.OBSEvents.UI;
 using LiveSplit.OBSEvents.Utility;
 using LiveSplit.UI;
 using LiveSplit.UI.Components;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Xml;
 
 namespace LiveSplit.OBSEvents;
 
@@ -52,7 +52,7 @@ public sealed class OBSEventsComponent : LogicComponent
             await Task.Delay(TimeSpan.FromSeconds(_settings.ReplayDelay));
         }
 
-        if (_settings.SaveBestSegmentReplay && LiveSplitStateHelper.CheckBestSegment(_state, index, method))
+        if (_settings.SaveBestSegmentReplay && IsBestSegment(_state, index, method))
         {
             try
             {
@@ -63,6 +63,23 @@ public sealed class OBSEventsComponent : LogicComponent
                 Logger.Error(ex.Message);
             }
         }
+    }
+
+    private bool IsBestSegment(LiveSplitState state, int index, TimingMethod method)
+    {
+        // mostly copied from LiveSplitStateHelper.CheckBestSegment
+
+        if (state.Run[index].SplitTime[method] == null)
+        {
+            return false;
+        }
+
+        TimeSpan? delta = LiveSplitStateHelper.GetPreviousSegmentDelta(state, index, BestSegmentsComparisonGenerator.ComparisonName, method);
+        TimeSpan? curSegment = LiveSplitStateHelper.GetPreviousSegmentTime(state, index, method);
+        TimeSpan? bestSegment = state.Run[index].BestSegmentTime[method];
+        TimeSpan? diffToBest = curSegment - bestSegment;
+        TimeSpan? threshold = TimeSpan.FromSeconds(_settings.ReplayThreshold);
+        return bestSegment == null || diffToBest < threshold || delta < TimeSpan.Zero;
     }
 
     public const string Name = "OBS Events";

--- a/src/LiveSplit.OBSEvents/UI/OBSEventsSettings.Designer.cs
+++ b/src/LiveSplit.OBSEvents/UI/OBSEventsSettings.Designer.cs
@@ -53,6 +53,8 @@ partial class OBSEventsSettings
             this.label5 = new System.Windows.Forms.Label();
             this.textReplayDelay = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label6 = new System.Windows.Forms.Label();
+            this.textReplayThreshold = new System.Windows.Forms.TextBox();
             this.groupOBSConnection.SuspendLayout();
             this.tableConnectionParams.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
@@ -265,19 +267,19 @@ partial class OBSEventsSettings
             this.textDebugLog.AcceptsReturn = true;
             this.textDebugLog.Dock = System.Windows.Forms.DockStyle.Fill;
             this.textDebugLog.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.textDebugLog.Location = new System.Drawing.Point(3, 305);
+            this.textDebugLog.Location = new System.Drawing.Point(3, 331);
             this.textDebugLog.Multiline = true;
             this.textDebugLog.Name = "textDebugLog";
             this.textDebugLog.ReadOnly = true;
             this.textDebugLog.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.textDebugLog.Size = new System.Drawing.Size(465, 247);
+            this.textDebugLog.Size = new System.Drawing.Size(465, 221);
             this.textDebugLog.TabIndex = 2;
             this.textDebugLog.Visible = false;
             // 
             // checkShowDebugLog
             // 
             this.checkShowDebugLog.AutoSize = true;
-            this.checkShowDebugLog.Location = new System.Drawing.Point(3, 282);
+            this.checkShowDebugLog.Location = new System.Drawing.Point(3, 308);
             this.checkShowDebugLog.Name = "checkShowDebugLog";
             this.checkShowDebugLog.Size = new System.Drawing.Size(109, 17);
             this.checkShowDebugLog.TabIndex = 3;
@@ -292,7 +294,7 @@ partial class OBSEventsSettings
             this.groupSaveBest.Dock = System.Windows.Forms.DockStyle.Fill;
             this.groupSaveBest.Location = new System.Drawing.Point(3, 182);
             this.groupSaveBest.Name = "groupSaveBest";
-            this.groupSaveBest.Size = new System.Drawing.Size(465, 94);
+            this.groupSaveBest.Size = new System.Drawing.Size(465, 120);
             this.groupSaveBest.TabIndex = 4;
             this.groupSaveBest.TabStop = false;
             this.groupSaveBest.Text = "Save Best Segment Replays";
@@ -309,14 +311,17 @@ partial class OBSEventsSettings
             this.tableLayoutPanel5.Controls.Add(this.textReplayFilename, 1, 1);
             this.tableLayoutPanel5.Controls.Add(this.label5, 0, 2);
             this.tableLayoutPanel5.Controls.Add(this.textReplayDelay, 1, 2);
+            this.tableLayoutPanel5.Controls.Add(this.label6, 0, 3);
+            this.tableLayoutPanel5.Controls.Add(this.textReplayThreshold, 1, 3);
             this.tableLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel5.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel5.Name = "tableLayoutPanel5";
-            this.tableLayoutPanel5.RowCount = 3;
+            this.tableLayoutPanel5.RowCount = 4;
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel5.Size = new System.Drawing.Size(459, 75);
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel5.Size = new System.Drawing.Size(459, 101);
             this.tableLayoutPanel5.TabIndex = 0;
             // 
             // checkSaveBestSegments
@@ -346,7 +351,7 @@ partial class OBSEventsSettings
             // textReplayFilename
             // 
             this.textReplayFilename.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.textReplayFilename.Location = new System.Drawing.Point(94, 26);
+            this.textReplayFilename.Location = new System.Drawing.Point(114, 26);
             this.textReplayFilename.Name = "textReplayFilename";
             this.textReplayFilename.Size = new System.Drawing.Size(362, 20);
             this.textReplayFilename.TabIndex = 2;
@@ -364,7 +369,7 @@ partial class OBSEventsSettings
             // textReplayDelay
             // 
             this.textReplayDelay.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.textReplayDelay.Location = new System.Drawing.Point(94, 52);
+            this.textReplayDelay.Location = new System.Drawing.Point(114, 52);
             this.textReplayDelay.Name = "textReplayDelay";
             this.textReplayDelay.Size = new System.Drawing.Size(362, 20);
             this.textReplayDelay.TabIndex = 4;
@@ -385,6 +390,24 @@ partial class OBSEventsSettings
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tableLayoutPanel1.Size = new System.Drawing.Size(459, 35);
             this.tableLayoutPanel1.TabIndex = 5;
+            // 
+            // label6
+            // 
+            this.label6.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(3, 81);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(105, 13);
+            this.label6.TabIndex = 5;
+            this.label6.Text = "Threshold (Seconds)";
+            // 
+            // textReplayThreshold
+            // 
+            this.textReplayThreshold.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textReplayThreshold.Location = new System.Drawing.Point(114, 78);
+            this.textReplayThreshold.Name = "textReplayThreshold";
+            this.textReplayThreshold.Size = new System.Drawing.Size(362, 20);
+            this.textReplayThreshold.TabIndex = 6;
             // 
             // OBSEventsSettings
             // 
@@ -440,4 +463,6 @@ partial class OBSEventsSettings
     private System.Windows.Forms.TextBox textDebugLog;
     private System.Windows.Forms.Label label5;
     private System.Windows.Forms.TextBox textReplayDelay;
+    private System.Windows.Forms.Label label6;
+    private System.Windows.Forms.TextBox textReplayThreshold;
 }

--- a/src/LiveSplit.OBSEvents/UI/OBSEventsSettings.cs
+++ b/src/LiveSplit.OBSEvents/UI/OBSEventsSettings.cs
@@ -18,14 +18,15 @@ public partial class OBSEventsSettings : UserControl
     {
         InitializeComponent();
 
-        textHost.DataBindings.Add(nameof(TextBox.Text), this, nameof(Host), false, DataSourceUpdateMode.OnPropertyChanged);
-        textPort.DataBindings.Add(nameof(TextBox.Text), this, nameof(Port), false, DataSourceUpdateMode.OnPropertyChanged);
-        textPassword.DataBindings.Add(nameof(TextBox.Text), this, nameof(Password), false, DataSourceUpdateMode.OnPropertyChanged);
+        textHost.DataBindings.Add(nameof(TextBox.Text), this, nameof(Host), false, DataSourceUpdateMode.OnValidation);
+        textPort.DataBindings.Add(nameof(TextBox.Text), this, nameof(Port), false, DataSourceUpdateMode.OnValidation);
+        textPassword.DataBindings.Add(nameof(TextBox.Text), this, nameof(Password), false, DataSourceUpdateMode.OnValidation);
         checkAutoConnect.DataBindings.Add(nameof(CheckBox.Checked), this, nameof(ConnectAutomatically), false, DataSourceUpdateMode.OnPropertyChanged);
         
         checkSaveBestSegments.DataBindings.Add(nameof(CheckBox.Checked), this, nameof(SaveBestSegmentReplay), false, DataSourceUpdateMode.OnPropertyChanged);
-        textReplayFilename.DataBindings.Add(nameof(TextBox.Text), this, nameof(ReplayNameFormat), false, DataSourceUpdateMode.OnPropertyChanged);
-        textReplayDelay.DataBindings.Add(nameof(TextBox.Text), this, nameof(ReplayDelay), false, DataSourceUpdateMode.OnPropertyChanged);
+        textReplayFilename.DataBindings.Add(nameof(TextBox.Text), this, nameof(ReplayNameFormat), false, DataSourceUpdateMode.OnValidation);
+        textReplayDelay.DataBindings.Add(nameof(TextBox.Text), this, nameof(ReplayDelay), false, DataSourceUpdateMode.OnValidation);
+        textReplayThreshold.DataBindings.Add(nameof(TextBox.Text), this, nameof(ReplayThreshold), false, DataSourceUpdateMode.OnValidation);
 
         Logger.AddErrorConsumer(LogError);
         Logger.AddWarningConsumer(LogWarning);
@@ -45,7 +46,9 @@ public partial class OBSEventsSettings : UserControl
 
     public string ReplayNameFormat { get; set; } = "%game-%category-%segment-%time";
 
-    public int ReplayDelay { get; set; } = 0;
+    public double ReplayDelay { get; set; } = 0;
+
+    public double ReplayThreshold { get; set; } = 0;
 
     internal Client Client { get; private set; } = null;
 
@@ -110,7 +113,8 @@ public partial class OBSEventsSettings : UserControl
 
         SaveBestSegmentReplay = SettingsHelper.ParseBool(element[nameof(SaveBestSegmentReplay)], SaveBestSegmentReplay);
         ReplayNameFormat = SettingsHelper.ParseString(element[nameof(ReplayNameFormat)], ReplayNameFormat);
-        ReplayDelay = SettingsHelper.ParseInt(element[nameof(ReplayDelay)], ReplayDelay);
+        ReplayDelay = SettingsHelper.ParseDouble(element[nameof(ReplayDelay)], ReplayDelay);
+        ReplayThreshold = SettingsHelper.ParseDouble(element[nameof(ReplayThreshold)], ReplayThreshold);
     }
 
     private int CreateSettingsNodes(XmlDocument document, XmlElement parent)
@@ -118,7 +122,8 @@ public partial class OBSEventsSettings : UserControl
         return SettingsHelper.CreateSetting(document, parent, nameof(ConnectAutomatically), ConnectAutomatically)
             ^ SettingsHelper.CreateSetting(document, parent, nameof(SaveBestSegmentReplay), SaveBestSegmentReplay)
             ^ SettingsHelper.CreateSetting(document, parent, nameof(ReplayNameFormat), ReplayNameFormat)
-            ^ SettingsHelper.CreateSetting(document, parent, nameof(ReplayDelay), ReplayDelay);
+            ^ SettingsHelper.CreateSetting(document, parent, nameof(ReplayDelay), ReplayDelay)
+            ^ SettingsHelper.CreateSetting(document, parent, nameof(ReplayThreshold), ReplayThreshold);
     }
 
     private async void buttonConnectToObs_Click(object sender, EventArgs e)


### PR DESCRIPTION
Resolves #11.

Also:
- changes Delay to allow fractional seconds
- changes text field data bindings to update on validation. Updating on property change was preventing me from typing a non-integer values for Delay and Threshold.

I'll shortly be writing a separate PR to add tooltips for Replay Filename, Delay, and Threshold. When those are in place, I'll remove the ugly `(Seconds)` suffix on the Delay and Threshold labels.