### PR TITLE
set UpdateName to ComponentName

### DIFF
--- a/src/LiveSplit.OBSEvents/OBSEventsFactory.cs
+++ b/src/LiveSplit.OBSEvents/OBSEventsFactory.cs
@@ -31,6 +31,5 @@ public sealed class OBSEventsFactory : IComponentFactory
     public IComponent Create(LiveSplitState state)
         => new OBSEventsComponent(state);
 
-    // This property is unused.
-    public string UpdateName => throw null;
+    public string UpdateName => ComponentName;
 }


### PR DESCRIPTION
The template that I built this from made an incorrect assertion about the `UpdateName` property in the component factory. The update helper in LiveSplit uses this property to build the dialog that it shows when it asks if you want to update the component.

Throwing null here was causing the updater to silently* fail. For everything! Pretty Bad

<details><summary>Not *fully* silent, but...</summary>
<p> 
It throws a message in the event log. But even the small, small minority of users that know that it exists and that LiveSplit writes to it are not going to check there. And there's no direct messaging to tell the user that a problem occurred, they won't know that there's something to check for.

Really Bad
</p>
</details>